### PR TITLE
[php-symfony] remove nested Valid constraint

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/api_input_validation.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/api_input_validation.mustache
@@ -19,11 +19,11 @@
     {{#items}}
         $asserts[] = new Assert\All([
             new Assert\Type("{{dataType}}"),
-            {{^isPrimitiveType}}
-            new Assert\Valid(),
-            {{/isPrimitiveType}}
         ]);
     {{/items}}
+    {{^isPrimitiveType}}
+        $asserts[] = new Assert\Valid();
+    {{/isPrimitiveType}}
 {{/isContainer}}
 {{^isContainer}}
     {{#isDate}}

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
@@ -257,6 +257,7 @@ class PetController extends Controller
         $asserts[] = new Assert\All([
             new Assert\Type("string"),
         ]);
+        $asserts[] = new Assert\Valid();
         $response = $this->validate($status, $asserts);
         if ($response instanceof Response) {
             return $response;
@@ -345,6 +346,7 @@ class PetController extends Controller
         $asserts[] = new Assert\All([
             new Assert\Type("string"),
         ]);
+        $asserts[] = new Assert\Valid();
         $response = $this->validate($tags, $asserts);
         if ($response instanceof Response) {
             return $response;

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/UserController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/UserController.php
@@ -163,8 +163,8 @@ class UserController extends Controller
         $asserts[] = new Assert\NotNull();
         $asserts[] = new Assert\All([
             new Assert\Type("OpenAPI\Server\Model\User"),
-            new Assert\Valid(),
         ]);
+        $asserts[] = new Assert\Valid();
         $response = $this->validate($body, $asserts);
         if ($response instanceof Response) {
             return $response;
@@ -242,8 +242,8 @@ class UserController extends Controller
         $asserts[] = new Assert\NotNull();
         $asserts[] = new Assert\All([
             new Assert\Type("OpenAPI\Server\Model\User"),
-            new Assert\Valid(),
         ]);
+        $asserts[] = new Assert\Valid();
         $response = $this->validate($body, $asserts);
         if ($response instanceof Response) {
             return $response;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Should fix the [Valid](https://symfony.com/doc/current/reference/constraints/Valid.html) nested in [All](https://symfony.com/doc/current/reference/constraints/All.html) as described in issue #2708 (use steps to reproduce documented there):
> The constraint Valid cannot be nested inside constraint Symfony\Component\Validator\Constraints\All. You can only declare the Valid constraint directly on a field or method.

Technical committee:
@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ackintosh (2017/09) ❤️, @ybelenko (2018/07), @renepardon (2018/12)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
